### PR TITLE
ci: add test/lint/type-check workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Lint, type-check & test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --extra dev --python 3.11
+
+      # ruff is not a project dependency (configured under [tool.ruff] only),
+      # so run it as a pinned ephemeral tool rather than via `uv run`.
+      - name: Lint (ruff)
+        run: uvx ruff@0.15.13 check src/
+
+      - name: Type check (mypy)
+        run: uv run mypy src/
+
+      - name: Test (pytest)
+        run: uv run pytest tests/

--- a/src/unraid/monitors/system_monitor.py
+++ b/src/unraid/monitors/system_monitor.py
@@ -141,7 +141,11 @@ class UnraidSystemMonitor:
     async def _rate_limited_alert(self, key: str, **kwargs: Any) -> None:
         """Send an alert only if cooldown has elapsed for this key."""
         now = time.monotonic()
-        last = self._last_alert_times.get(key, 0)
+        # Default to -inf (not 0) so the first alert always fires: on a
+        # freshly-booted host time.monotonic() can be < _ALERT_COOLDOWN, and a
+        # sentinel of 0 would wrongly suppress the very first alert within the
+        # first few minutes of uptime.
+        last = self._last_alert_times.get(key, float("-inf"))
         if now - last < _ALERT_COOLDOWN:
             logger.debug(f"Suppressing duplicate {key} alert (cooldown)")
             return

--- a/tests/test_formatting_utils.py
+++ b/tests/test_formatting_utils.py
@@ -227,12 +227,17 @@ class TestFormatMuteExpiry:
     """Tests for format_mute_expiry."""
 
     def test_same_day(self):
+        from unittest.mock import patch
         from zoneinfo import ZoneInfo
 
         tz = ZoneInfo("Europe/London")
-        now = datetime.now(tz)
-        expiry = now + timedelta(hours=1)
-        result = format_mute_expiry(expiry)
+        # Pin "now" to midday so expiry (+1h) cannot roll into tomorrow.
+        # Using the real clock made this flaky in the last hour before midnight.
+        fixed_now = datetime(2026, 6, 2, 12, 0, tzinfo=tz)
+        with patch("src.utils.formatting.datetime") as mock_dt:
+            mock_dt.now.return_value = fixed_now
+            expiry = fixed_now + timedelta(hours=1)
+            result = format_mute_expiry(expiry)
         assert result.startswith("until ")
         assert "tomorrow" not in result
 


### PR DESCRIPTION
## What

Adds `.github/workflows/ci.yml` that runs on **push** and **pull_request** to `master` (plus `workflow_dispatch`):

- **Lint** — `uvx ruff@0.15.13 check src/`
- **Type-check** — `uv run mypy src/` (strict)
- **Test** — `uv run pytest tests/` (full suite, 1065 tests)

## Why

The repo already had a 75-file test suite, `ruff`, and strict `mypy` configured in `pyproject.toml` — but nothing ran them automatically. The only existing workflow was the Docker Hub description sync, so **regressions could ship undetected**. Surfaced as the #1 (and only) table-stakes gap in a SOTA benchmark against the self-hosted Docker/server-monitoring field.

## Two bugs the new CI caught on its first run 🎯

Running in a fresh **UTC** VM (vs. the maintainer's long-uptime `Europe/London` box) immediately exposed two latent issues — now fixed in this PR:

1. **Production bug — first server alert suppressed within 5 min of boot.**
   `UnraidSystemMonitor._rate_limited_alert` used a sentinel of `0` for "never alerted". `time.monotonic()` is seconds-since-boot, so on a freshly-booted host (`monotonic < _ALERT_COOLDOWN = 300`), the cooldown check `now - 0 < 300` was true and the **very first** CPU-temp / memory / CPU-usage alert was silently dropped for the first ~5 minutes of uptime — exactly when a hot reboot would most need it. Fixed by defaulting to `-inf`. Reproduced at 5s simulated uptime (85 °C alert suppressed before the fix; fires after).

2. **Flaky test — `test_same_day`.** Asserted `"tomorrow" not in` a `now + 1h` mute expiry, which breaks in the last hour before midnight. Pinned "now" to midday.

## Notes

- **ruff** is configured under `[tool.ruff]` but is *not* a declared dependency, so `uv run ruff` fails on a clean runner. The workflow runs it as a pinned ephemeral tool via `uvx ruff@0.15.13`. `pytest`/`mypy` are in the `dev` extra, so `uv run` works for those after `uv sync --extra dev`.
- Pinned to Python 3.11 to match the Docker target (`python:3.11-slim`).
- uv dependency cache enabled via `astral-sh/setup-uv@v5`.
- Heads-up (non-blocking): GitHub warns `actions/checkout@v4` + `setup-uv@v5` run on Node 20, which is being phased out ~June 16 2026. A later bump to newer action majors will clear the warning.

## Verified

- ✅ CI green on GitHub runners: ruff, mypy, **pytest 1065 passed**
- ✅ Full suite passes locally under both `TZ=UTC` and `TZ=Europe/London`